### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/hw3/experiments/test.py
+++ b/hw3/experiments/test.py
@@ -11,21 +11,21 @@ class TerminalColors:
     RESET = '\033[0m'
 
 
-def get_pyautogen_version() -> Tuple[bool, str]:
+def get_ag2_version() -> Tuple[bool, str]:
     """Return (is_installed, version)."""
     try:
         try:
             from importlib.metadata import version, PackageNotFoundError
         except ImportError:  # For Python < 3.8
             from importlib_metadata import version, PackageNotFoundError
-        return True, version("pyautogen")
+        return True, version("ag2")
     except PackageNotFoundError:
         return False, ""
 
 
-def check_pyautogen_version(expected: str = "0.9.0") -> bool:
-    """Check if pyautogen is installed and matches the expected version."""
-    present, ver = get_pyautogen_version()
+def check_ag2_version(expected: str = "0.9.0") -> bool:
+    """Check if ag2 is installed and matches the expected version."""
+    present, ver = get_ag2_version()
     if not present:
         print(f"{TerminalColors.RED}[X] Test 0 Failed. Pyautogen missing.{TerminalColors.RESET}")
         return False
@@ -33,7 +33,7 @@ def check_pyautogen_version(expected: str = "0.9.0") -> bool:
         print(f"{TerminalColors.GREEN}[V] Test 0 Passed. Pyautogen {ver}{TerminalColors.RESET}")
         return True
     print(
-        f"{TerminalColors.RED}pyautogen version mismatch — installed: {ver} expected: {expected}{TerminalColors.RESET}"
+        f"{TerminalColors.RED}ag2 version mismatch — installed: {ver} expected: {expected}{TerminalColors.RESET}"
     )
     return False
 
@@ -132,5 +132,5 @@ def public_tests() -> None:
 
 
 if __name__ == "__main__":
-    check_pyautogen_version("0.9.0")
+    check_ag2_version("0.9.0")
     public_tests()


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
